### PR TITLE
Fix: TypeError: __call__() missing 1 required positional argument: 'send'

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ COPY . .
 EXPOSE 5001
 
 # Set the Gunicorn command to start the server
-CMD ["gunicorn", "app:app", "--bind", "0.0.0.0:5001", "--timeout", "180"]
+CMD ["gunicorn", "-k", "uvicorn.workers.UvicornWorker", "app:app", "--bind", "0.0.0.0:5001", "--timeout", "180"]
 
 # Build the Docker image:
 # docker build -t flask-app .


### PR DESCRIPTION
# Changes
The Dockerfile's Gunicorn command for starting the server has been updated. It now uses UvicornWorker instead of simply running the app to avoid the missing 1 required positional argument send error.

# Context
I was getting the following error when starting the container following the instructions from the readme
```
"/usr/local/lib/python3.11/site-packages/gunicorn/workers/sync.py", line 178, in handle_request 2024-05-31 07:59:38 respiter = self.wsgi(environ, resp.start_response) 2024-05-31 07:59:38 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 2024-05-31 07:59:38 TypeError: FastAPI.__call__() missing 1 required positional argument: 'send'
```

Following the suggestions from https://github.com/benoitc/gunicorn/issues/2154 I added `-k uvicorn.workers.UvicornWorker` to the Dockerfile